### PR TITLE
Add center and type interpretations for Phase 2

### DIFF
--- a/src/app/api/reference/centers/route.ts
+++ b/src/app/api/reference/centers/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { CENTERS, getCenter } from '@/lib/reference/centers';
+import type { CenterName } from '@/types';
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const key = searchParams.get('key') as CenterName | null;
+
+    if (key) {
+      const center = getCenter(key);
+      if (!center) {
+        return NextResponse.json(
+          { error: 'Center not found' },
+          { status: 404 }
+        );
+      }
+      return NextResponse.json(center);
+    }
+
+    // Return all centers
+    return NextResponse.json(CENTERS);
+  } catch (error) {
+    console.error('Centers reference error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/reference/types/route.ts
+++ b/src/app/api/reference/types/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { TYPES, getType } from '@/lib/reference/types';
+import type { HumanDesignType } from '@/types';
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const name = searchParams.get('name') as HumanDesignType | null;
+
+    if (name) {
+      const type = getType(name);
+      if (!type) {
+        return NextResponse.json(
+          { error: 'Type not found' },
+          { status: 404 }
+        );
+      }
+      return NextResponse.json(type);
+    }
+
+    // Return all types
+    return NextResponse.json(TYPES);
+  } catch (error) {
+    console.error('Types reference error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/reference/centers.ts
+++ b/src/lib/reference/centers.ts
@@ -1,0 +1,110 @@
+import type { CenterName } from '@/types';
+
+export interface CenterReference {
+  name: string;
+  key: CenterName;
+  theme: string;
+  definedDescription: string;
+  undefinedDescription: string;
+  notSelfTheme: string;
+}
+
+/**
+ * All 9 Human Design Centers with interpretation data
+ */
+export const CENTERS: CenterReference[] = [
+  {
+    name: 'Head',
+    key: 'head',
+    theme: 'Inspiration & Mental Pressure',
+    definedDescription: 'You have a consistent way of processing mental inspiration and questions. Your mind generates questions and ideas from a fixed place within you. You have a reliable mental pressure that drives you to think about specific types of questions and concepts. This is your consistent source of mental inspiration.',
+    undefinedDescription: 'You are open and receptive to the mental pressure and inspiration of others. You can take in many different ways of thinking and question asking. You amplify the mental pressure of those around you and can become deeply identified with questions that aren\'t yours. Your openness here is designed to sample many different ways of thinking and gain wisdom about mental pressure.',
+    notSelfTheme: 'Mental pressure to answer questions that don\'t matter to you, trying to prove you\'re intelligent by having all the answers, becoming overwhelmed by mental pressure from others.'
+  },
+  {
+    name: 'Ajna',
+    key: 'ajna',
+    theme: 'Conceptualization & Mental Awareness',
+    definedDescription: 'You have a fixed way of processing and conceptualizing information. Your mental awareness and way of thinking about things is consistent and reliable. You think about life through a particular filter or lens that doesn\'t change. This gives you a dependable mental awareness and way of making sense of experiences and information.',
+    undefinedDescription: 'You are open and flexible in how you think about and conceptualize life. You can see things from many different perspectives and are capable of incredible mental flexibility. You amplify and experience different ways of thinking and can become attached to certainty and fixed opinions as you seek to feel mentally secure. Your openness allows you to gain wisdom about different ways of thinking.',
+    notSelfTheme: 'Pretending to be certain when you\'re not, getting locked into fixed opinions to feel secure, mental inflexibility born from fear of not knowing.'
+  },
+  {
+    name: 'Throat',
+    key: 'throat',
+    theme: 'Manifestation & Communication',
+    definedDescription: 'You have consistent access to manifestation and expression. Your voice and ability to communicate or take action in the world is reliable. You have a fixed way of bringing things into form through speech or action. How you manifest depends on what connects to your Throat - whether through motor centers (action) or awareness centers (communication).',
+    undefinedDescription: 'You are open in how you communicate and manifest. You can speak and act in many different ways and are designed to sample diverse forms of expression. You amplify the communication of others and may feel pressure to speak or initiate action to be heard or noticed. Your openness allows you to become wise about communication and knowing when to speak.',
+    notSelfTheme: 'Talking to get attention, initiating action to prove your worth, speaking when you have nothing to say, struggling to be heard.'
+  },
+  {
+    name: 'G Center (Identity)',
+    key: 'g',
+    theme: 'Identity, Direction & Love',
+    definedDescription: 'You have a fixed sense of self and direction in life. Your identity and life path are consistent - you know who you are and where you\'re going, even if the how and when remain mysterious. You have a reliable sense of self that doesn\'t change based on your environment or the people around you. Your direction in life comes from within.',
+    undefinedDescription: 'You are open and fluid in your sense of self and direction. You experience many different identities and life directions through the people and places around you. You can deeply identify with others and their paths, searching for yourself in relationships and environments. Your openness allows you to gain wisdom about identity and direction, understanding that you are designed to experience many selves.',
+    notSelfTheme: 'Searching for yourself in others and places, lacking a consistent sense of who you are, trying to hold onto one fixed identity, feeling lost without a clear direction.'
+  },
+  {
+    name: 'Ego (Heart/Will)',
+    key: 'ego',
+    theme: 'Willpower & Self-Worth',
+    definedDescription: 'You have consistent access to willpower and self-worth. Your ego strength and ability to make and keep promises is reliable. You have a fixed sense of your own value and consistent access to willpower for things that are correct for you. You can make commitments and have the will to follow through when it\'s aligned with your design.',
+    undefinedDescription: 'You are open in the realm of willpower and self-worth. You experience willpower inconsistently and can amplify the ego energy of others. You may try to prove your worth or make promises you can\'t keep to feel valuable. Your openness allows you to become wise about self-worth, learning that your value is not based on what you do or prove, and that rest is essential.',
+    notSelfTheme: 'Trying to prove yourself worthy, making promises you can\'t keep, over-committing and burning out, tying your value to productivity and achievement.'
+  },
+  {
+    name: 'Sacral',
+    key: 'sacral',
+    theme: 'Life Force & Response',
+    definedDescription: 'You have consistent access to life force energy and the power to sustain work. Your Sacral motor gives you reliable energy for doing when you\'re responding to life. You are designed to work, build, and engage with life through response. Your energy is a powerful resource when used correctly - responding to what life brings rather than initiating.',
+    undefinedDescription: 'You do not have consistent access to life force energy. You are not designed to work in the same sustainable way as Sacral beings. You take in and amplify Sacral energy, which can make you feel like you have more energy than you do. Your openness here is about learning when enough is enough and recognizing that your energy works in cycles, requiring rest and restoration.',
+    notSelfTheme: 'Exhaustion from overworking, not knowing when to stop, feeling like you should be able to work as much as others, ignoring your need for rest.'
+  },
+  {
+    name: 'Solar Plexus (Emotional)',
+    key: 'solar_plexus',
+    theme: 'Emotions & Emotional Awareness',
+    definedDescription: 'You have a consistent emotional wave and emotional authority. Your emotions move in waves - highs and lows - that are not caused by external circumstances but are your natural chemistry. You are here to ride your emotional wave and wait for clarity over time before making major decisions. Your emotional awareness is a powerful guidance system when you honor your wave.',
+    undefinedDescription: 'You are open and receptive to the emotions of others. You take in, amplify, and can deeply feel the emotional waves of those around you. You may struggle to know which emotions are yours and can become attached to keeping the peace or avoiding confrontation. Your openness allows you to develop empathy and emotional wisdom, learning to let emotions flow through you without holding on.',
+    notSelfTheme: 'Avoiding confrontation to keep the peace, holding onto emotions that aren\'t yours, trying to maintain emotional highs or fix emotional lows, people-pleasing to avoid negative emotions.'
+  },
+  {
+    name: 'Spleen',
+    key: 'spleen',
+    theme: 'Intuition, Health & Survival',
+    definedDescription: 'You have consistent access to splenic intuition and body intelligence. Your awareness of health, safety, and well-being is reliable and speaks to you in the moment. Your splenic awareness is spontaneous, only speaks once, and is designed to keep you safe and healthy. You have a dependable intuitive knowing that comes from your body.',
+    undefinedDescription: 'You are open to splenic awareness and can experience many forms of intuition and body intelligence. You amplify fears and health concerns, and may hold onto things, people, or situations that aren\'t healthy out of fear. Your openness allows you to become wise about fear, health, and well-being, learning to recognize what is truly dangerous versus conditioned fear.',
+    notSelfTheme: 'Holding onto what\'s not good for you out of fear, amplifying health anxieties, being unable to let go of people or situations that are unhealthy, making fear-based decisions.'
+  },
+  {
+    name: 'Root',
+    key: 'root',
+    theme: 'Pressure & Drive',
+    definedDescription: 'You have consistent pressure and drive to do, evolve, and move. Your Root motor provides reliable fuel for action and momentum. You experience a steady pressure to complete things, move forward, and get things done. This pressure is your fuel, but it\'s important to use it correctly according to your Type and Strategy rather than letting it run you.',
+    undefinedDescription: 'You are open to pressure and adrenaline from others and the world. You amplify stress and pressure, which can make you feel like you\'re always running out of time or need to hurry. You may rush to relieve pressure that isn\'t even yours. Your openness allows you to become wise about pressure and develop the capacity to remain calm in stressful situations, knowing most pressure is not yours to carry.',
+    notSelfTheme: 'Always feeling rushed and under pressure, hurrying to get things done to relieve pressure, stress and anxiety about time, taking on stress from others as if it\'s your own.'
+  }
+];
+
+/**
+ * Center lookup by key
+ */
+export const CENTER_MAP: Record<CenterName, CenterReference> = {
+  head: CENTERS[0],
+  ajna: CENTERS[1],
+  throat: CENTERS[2],
+  g: CENTERS[3],
+  ego: CENTERS[4],
+  sacral: CENTERS[5],
+  solar_plexus: CENTERS[6],
+  spleen: CENTERS[7],
+  root: CENTERS[8],
+};
+
+/**
+ * Get center reference by key
+ */
+export function getCenter(key: CenterName): CenterReference | undefined {
+  return CENTER_MAP[key];
+}

--- a/src/lib/reference/index.ts
+++ b/src/lib/reference/index.ts
@@ -1,2 +1,4 @@
+export * from './centers';
 export * from './channels';
 export * from './crosses';
+export * from './types';

--- a/src/lib/reference/types.ts
+++ b/src/lib/reference/types.ts
@@ -1,0 +1,74 @@
+import type { HumanDesignType, Strategy } from '@/types';
+
+export interface TypeReference {
+  name: HumanDesignType;
+  strategy: Strategy;
+  signature: string;
+  notSelf: string;
+  description: string;
+  aura: string;
+}
+
+/**
+ * All 5 Human Design Types with interpretation data
+ */
+export const TYPES: TypeReference[] = [
+  {
+    name: 'Manifestor',
+    strategy: 'Inform',
+    signature: 'Peace',
+    notSelf: 'Anger',
+    description: 'Manifestors are the only Type designed to initiate action without waiting. You are here to make things happen and impact others with your energy. Your aura is closed and repelling, designed to push through resistance and make things happen. You represent about 9% of the population. Your Strategy is to inform those who will be impacted by your actions before you act. When you inform, you minimize resistance and move through life with greater ease. Your power lies in your ability to start things, but you are not designed to do all the work yourself - that\'s for Generators. You\'re here to initiate, inform, and then let others help bring your visions into form. When you\'re living correctly, you experience peace. When you\'re not informing or trying to force things, you experience anger.',
+    aura: 'Closed and repelling - designed to push through and impact. Your aura creates resistance naturally, which is why informing is so important to minimize that resistance.'
+  },
+  {
+    name: 'Generator',
+    strategy: 'Wait to Respond',
+    signature: 'Satisfaction',
+    notSelf: 'Frustration',
+    description: 'Generators are the life force of the planet, representing about 37% of the population (pure Generators, not including Manifesting Generators). You have a defined Sacral center that gives you consistent access to sustainable life force energy. Your Strategy is to wait to respond - to let life come to you and respond with your Sacral sounds (uh-huh or uhn-uhn). You are not designed to initiate, but to respond to what life brings. When you respond to things that light you up, you have incredible energy to work, build, and master what you love. Your power is in your response and your ability to know what is correct for you through that Sacral response. When you\'re responding correctly, you experience satisfaction and have energy for what you\'re doing. When you\'re initiating or doing things your Sacral didn\'t respond to, you experience frustration and exhaustion.',
+    aura: 'Open and enveloping - designed to draw life to you so you can respond. Your aura pulls people and opportunities in, giving you things to respond to.'
+  },
+  {
+    name: 'Manifesting Generator',
+    strategy: 'Wait to Respond',
+    signature: 'Satisfaction & Peace',
+    notSelf: 'Frustration & Anger',
+    description: 'Manifesting Generators are a hybrid Type combining Generator and Manifestor qualities, representing about 33% of the population. Like Generators, you have a defined Sacral and are designed to wait to respond. Like Manifestors, you have a motor connected to the Throat, giving you the ability to manifest and move quickly. You are the most multi-passionate, multi-talented Type, designed to do many things and skip steps. Your Strategy is to wait to respond, and once you respond, to inform before you act. You move fast, often faster than others can track, which is why informing is important. You\'re here to find the shortcuts and most efficient paths. When you respond correctly and inform, you experience both satisfaction (from responding) and peace (from informing). When you initiate without responding or act without informing, you experience frustration and anger.',
+    aura: 'Open and enveloping like Generators, but with manifestor-like impact - designed to respond, then move quickly and powerfully.'
+  },
+  {
+    name: 'Projector',
+    strategy: 'Wait for Invitation',
+    signature: 'Success',
+    notSelf: 'Bitterness',
+    description: 'Projectors are the guides and managers of humanity, representing about 20% of the population. You do not have a defined Sacral, which means you don\'t have consistent access to sustainable work energy. Your gift is in seeing others, seeing systems, and guiding energy effectively. Your Strategy is to wait for invitation - specifically for the big things in life (career, relationships, where you live). When you\'re invited and recognized, people are ready to hear your guidance. You\'re not here to work in the traditional sense, but to guide, manage, and direct the energy of others. Your aura is focused and penetrating - you see deeply into others and systems. When you wait for invitations and are recognized for your gifts, you experience success. When you try to force your way in or share your guidance without invitation, you experience bitterness and rejection.',
+    aura: 'Focused and penetrating - designed to see deeply into others and systems. Your aura takes in specific people and situations to understand them deeply.'
+  },
+  {
+    name: 'Reflector',
+    strategy: 'Wait Lunar Cycle',
+    signature: 'Surprise',
+    notSelf: 'Disappointment',
+    description: 'Reflectors are the rarest Type, representing about 1% of the population. You have no centers defined, which makes you completely open and receptive to the world around you. You are the ultimate mirrors of your community and environment, deeply sampling and reflecting the health of the world around you. Your Strategy is to wait a full lunar cycle (about 28 days) before making major decisions, as you experience the moon activating each gate and need that full cycle to gain clarity. You are deeply connected to the lunar cycle and experience life through the moon\'s transit. Your aura is resistant and sampling - you take everything in but in a protected way. You\'re here to experience all of life and reflect back the truth of what you experience. When you\'re in the right environment with the right people and honoring your lunar cycle, you experience surprise and delight. When you\'re in the wrong environment or rushing decisions, you experience disappointment.',
+    aura: 'Resistant and sampling - designed to take in and reflect everything while maintaining energetic protection. Your aura samples the world without being defined by it.'
+  }
+];
+
+/**
+ * Type lookup by name
+ */
+export const TYPE_MAP: Record<HumanDesignType, TypeReference> = {
+  'Manifestor': TYPES[0],
+  'Generator': TYPES[1],
+  'Manifesting Generator': TYPES[2],
+  'Projector': TYPES[3],
+  'Reflector': TYPES[4],
+};
+
+/**
+ * Get type reference by name
+ */
+export function getType(name: HumanDesignType): TypeReference | undefined {
+  return TYPE_MAP[name];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -188,12 +188,22 @@ export interface ChannelReference {
   description?: string;
 }
 
+export interface CenterReference {
+  name: string;
+  key: CenterName;
+  theme: string;
+  definedDescription: string;
+  undefinedDescription: string;
+  notSelfTheme: string;
+}
+
 export interface TypeReference {
-  id: HumanDesignType;
+  name: HumanDesignType;
   strategy: Strategy;
   signature: string;
-  not_self: string;
-  description?: string;
+  notSelf: string;
+  description: string;
+  aura: string;
 }
 
 export interface AuthorityReference {
@@ -215,6 +225,7 @@ export interface ReferenceData {
   type?: TypeReference;
   authority?: AuthorityReference;
   profile?: ProfileReference;
+  centers?: Record<string, CenterReference>;
   channels?: Record<string, ChannelReference>;
   gates?: Record<string, GateReference>;
 }


### PR DESCRIPTION
Implements comprehensive Human Design interpretation data for all 9 centers and 5 types as specified in Issue #25.

## Changes
- Created `src/lib/reference/centers.ts` with all 9 centers
- Created `src/lib/reference/types.ts` with all 5 types
- Added API endpoints: `/api/reference/centers` and `/api/reference/types`
- Added TypeScript types and updated interfaces

Closes #25

🤖 Generated with [Claude Code](https://claude.ai/code)