### PR TITLE
fix: Replace non-cross-platform cp command with Node.js script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "20.x"
   },
   "scripts": {
-    "postinstall": "cp node_modules/sweph-wasm/dist/wasm/swisseph.wasm public/swisseph.wasm",
+    "postinstall": "node scripts/copy-wasm.js",
     "dev": "next dev",
     "build": "next build",
     "build:ci": "npm ci && npm run build",

--- a/scripts/copy-wasm.js
+++ b/scripts/copy-wasm.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+const source = path.join(
+  __dirname,
+  '..',
+  'node_modules',
+  'sweph-wasm',
+  'dist',
+  'wasm',
+  'swisseph.wasm'
+);
+
+const dest = path.join(__dirname, '..', 'public', 'swisseph.wasm');
+
+try {
+  // Ensure public directory exists
+  const publicDir = path.dirname(dest);
+  if (!fs.existsSync(publicDir)) {
+    fs.mkdirSync(publicDir, { recursive: true });
+  }
+
+  // Copy file
+  fs.copyFileSync(source, dest);
+  console.log('✓ Copied swisseph.wasm to public directory');
+} catch (error) {
+  console.error('✗ Failed to copy swisseph.wasm:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
Fixes #21

## Changes
- Create scripts/copy-wasm.js for cross-platform WASM file copying
- Add error handling and directory creation
- Works on Windows, macOS, and Linux

## Testing
The postinstall script will run automatically after `npm install` on any platform.

----
Generated with [Claude Code](https://claude.ai/code)