### PR TITLE
fix: add robust WASM file path resolution for Vercel serverless

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,19 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  // Ensure WASM files are properly handled in serverless environment
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      // Copy WASM file to server output for serverless functions
+      config.module.rules.push({
+        test: /\.wasm$/,
+        type: 'asset/resource',
+        generator: {
+          filename: 'static/wasm/[name][ext]',
+        },
+      });
+    }
+    return config;
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
Fixes #4

## Summary
- Added robust WASM file path resolution for Vercel deployment

## Test plan
- [ ] Test in Vercel serverless environment
- [ ] Verify WASM loads correctly