### PR TITLE
fix: remove req.ip usage in generate-reading route

### DIFF
--- a/src/app/api/generate-reading/route.ts
+++ b/src/app/api/generate-reading/route.ts
@@ -32,7 +32,7 @@ function checkRateLimit(identifier: string): { allowed: boolean; retryAfter?: nu
 export async function POST(req: NextRequest) {
   try {
     // Rate limiting based on IP address
-    const identifier = req.ip || req.headers.get('x-forwarded-for') || 'anonymous';
+    const identifier = req.headers.get('x-forwarded-for') || 'anonymous';
     const rateLimit = checkRateLimit(identifier);
 
     if (!rateLimit.allowed) {


### PR DESCRIPTION
Fixes #54

Removed `req.ip` usage which doesn't exist on NextRequest type. Now uses only the `x-forwarded-for` header for rate limiting identifier.

This fixes the Vercel build failure:
```
Type error: Property 'ip' does not exist on type 'NextRequest'.
```

----
Generated with [Claude Code](https://claude.ai/code)