### PR TITLE
Update homepage h1 from white to theme-consistent subtle light gradient

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,3 +34,34 @@ body {
   );
   min-height: 100vh;
 }
+
+/* Subtle gradient text for headings */
+.gradient-heading {
+  background: linear-gradient(
+    135deg,
+    #27272a 0%,
+    #3f3f46 25%,
+    #52525b 50%,
+    #3f3f46 75%,
+    #27272a 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+@media (prefers-color-scheme: dark) {
+  .gradient-heading {
+    background: linear-gradient(
+      135deg,
+      #f8f8f8 0%,
+      #e4e4e7 25%,
+      #d4d4d8 50%,
+      #e4e4e7 75%,
+      #fafafa 100%
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,7 +39,7 @@ export default function Home() {
     <main className="min-h-screen p-4 md:p-8">
       <div className="max-w-4xl mx-auto">
         <header className="text-center mb-8">
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+          <h1 className="text-3xl md:text-4xl font-bold gradient-heading mb-2">
             Human Design Chart
           </h1>
           <p className="text-gray-600 dark:text-gray-400">


### PR DESCRIPTION
## Summary

Implements #56

## Implementation Details

**Effort Level:** THOROUGH
**Iterations:** 1

## Original Issue

## Description

The h1 on the homepage is currently plain white. Update it to use a subtle light gradient that is consistent with the overall theme.

## Requirements
- Change the h1 text color from solid white to a gradient
- Gradient should be subtle and light (not overpowering)
- Should complement the existing theme/design system
- Ensure readability is maintained

## Acceptance Criteria
- [ ] h1 displays with gradient text effect
- [ ] Gradient colors match theme palette
- [ ] Text remains readable on all backgrounds

---

_Generated by THE ALGORITHM - PAI Cloud Agent_
Closes #56